### PR TITLE
Add !terminalFocus context to ctrl+shift+c

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
             {
                 "key": "ctrl+shift+c",
                 "mac": "cmd+shift+c",
-                "command": "console.open"
+                "command": "console.open",
+                "when": "!terminalFocus"
             },
             {
                 "key": "ctrl+shift+a",


### PR DESCRIPTION
Without this is break copying within the integrated terminal.
